### PR TITLE
Allow SMW 5.X in composer.json (#248)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 	"require": {
 		"php": ">=7.3.0",
 		"composer/installers": ">=1.0.1",
-		"mediawiki/semantic-media-wiki": "~4.0|~3.1"
+		"mediawiki/semantic-media-wiki": "~3.1|~4.0|~5.0"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "43.0.0",


### PR DESCRIPTION
Following https://github.com/SemanticMediaWiki/SemanticScribunto/pull/101/commits/224cbca66f96a87451ee9a545a25cb6f5de38151

This PR is made in reference to: #

This PR addresses or contains:
- ...
- ...
- ...

This PR includes:
- [ ] Tests (unit/integration)
- [ ] CI build passed

Fixes #
